### PR TITLE
Migracja do Github Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,11 +22,10 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - run: ./gradlew clean test -Pbuild=dev
-      - run: find / -type d
-      - run: "find / -name '*.apk'"
+      - name: Run Gradle 
+        run: ./gradlew clean test -Pbuild=dev
       - name: Upload APK
         uses: actions/upload-artifact@v2
         with:
           name: App
-          path: ${{ github.workspace }}/app/build/outputs/apk/debug/app-debug.apk
+          path: ./app/app-release.apk

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+name: Tests
+
+on:
+  push:
+    branches: ['master']
+  pull_request:
+    branches: ['master']
+
+jobs:
+  build:
+    name: Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - run: ./gradlew clean test -Pbuild=dev
+      - run: find / -type d
+      - run: "find / -name '*.apk'"
+      - name: Upload APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: App
+          path: ${{ github.workspace }}/app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/clear_old_artifacts.yaml
+++ b/.github/workflows/clear_old_artifacts.yaml
@@ -1,0 +1,13 @@
+name: 'Delete old artifacts'
+on:
+  schedule:
+    - cron: '28 4 * * 1' # At 04:28 on Monday.
+
+jobs:
+  delete-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kolpav/purge-artifacts-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          expire-in: 30days # Setting this to 0 will delete all artifacts


### PR DESCRIPTION
Hello,

Przeniosłem nasz CI do Github Action. Na razie eksperymentalnie uruchamiane są zatem dwa CI i gdy to się sprawdzi to możemy skasować Travis.

Oprócz przyspieszeniaa (2m20 s vs 50s) to dodatkowy usprawnieniem jest [dostępność artefaktów](https://docs.github.com/en/free-pro-team@latest/actions/guides/storing-workflow-data-as-artifacts#downloading-or-deleting-artifacts) z zbudowaną aplikacją APK

Z wyrazami szacunku,