### PR TITLE
Naprawiono wyswietlanie tekstu na przycisku Zobacz przyjaciol Poli

### DIFF
--- a/app/src/main/res/layout/fragment_product_details_lidl.xml
+++ b/app/src/main/res/layout/fragment_product_details_lidl.xml
@@ -270,7 +270,7 @@
                     android:layout_marginRight="10dp"
                     android:layout_marginBottom="10dp"
                     android:background="@drawable/button_border"
-                    android:text="@string/zobacz_przyjaci_poli"
+                    android:text="@string/see_pola_friends"
                     android:textColor="#D8002F" />
 
             </LinearLayout>


### PR DESCRIPTION
###Numer issue :

 #145

###Opis zmian:
Tekst przycisku odwoływał się do nieistniejącego stringa w strings.xml. Zmiana polegała tylko na ustawieniu odpowiedniego stringa. 
